### PR TITLE
add support for release events (alternative approach)

### DIFF
--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -82,6 +82,11 @@ exports.parse = function (file) {
             pointer = pointer[inputCodes[keys[j]]];
         }
 
+        if (shortcut.release === true) {
+        	pointer[-1] = {};
+        	pointer = pointer[-1];
+        }
+
         pointer.command = shortcut.command;
         pointer.blocking = typeof shortcut.blocking !== 'undefined' 
             ? shortcut.blocking : false;

--- a/lib/device-listener.js
+++ b/lib/device-listener.js
@@ -52,14 +52,14 @@ exports.listen = function (device, callback) {
                 if (value === 1 && pressedKeys.indexOf(code) === -1) {
                     pressedKeys.push(code);
 
-                    // Keys are handled only when pressed
-
                     callback(pressedKeys);
                 }
 
                 // Event type key released 
 
                 if (value === 0 && pressedKeys.indexOf(code) !== -1) {
+                    callback([...pressedKeys, -1]);
+
                     pressedKeys.splice (pressedKeys.indexOf(code), 1);
                 }
                 


### PR DESCRIPTION
I think I was able to find a reasonable combination of both ideas. This version still uses the virtual keycode `-1` inside the internal data structure that holds the parsed version of the shortcuts, but it doesn't expose that to the user and instead uses the `release` property in the config JSON.

Example:
```json
{
    "device": "/dev/input/by-id/usb-Logitech_USB_Keyboard-event-kbd",
    "shortcuts": [{
        "keys": "KEY_LEFTCTRL+KEY_LEFTALT+KEY_1",
        "blocking": false,
        "command": "echo shortcut pressed" 
    }, {
        "keys": "KEY_LEFTCTRL+KEY_LEFTALT+KEY_1",
        "release": true,
        "blocking": false,
        "command": "echo shortcut released"
    }]
}
```

(This PR obviously replaces PR #2.)